### PR TITLE
Add API support for combined metrics

### DIFF
--- a/api_doc/transformer/get_combinator_metric_expression.yaml
+++ b/api_doc/transformer/get_combinator_metric_expression.yaml
@@ -18,12 +18,18 @@ responses:
         schema:
           type: object
           properties:
-            configItemName:
+            transformerId:
               type: string
-            configItems:
-              type: array
-              items:
-                $ref: "#/components/schemas/ConfigItem"
+              description: id of the combinator
+            metric:
+              type: string
+              description: id of the metric
+            expression:
+              type: object
+              description: the expression of the metric
+            configHash:
+              type: string
+              description: hash of current config, required for PATCH
   '404':
     description: metric not found for given combinator
 produces:

--- a/api_doc/transformer/get_combinator_metric_expression.yaml
+++ b/api_doc/transformer/get_combinator_metric_expression.yaml
@@ -1,0 +1,30 @@
+description: Get expression for a metric of a combinator
+tags:
+- Transformer
+parameters:
+- in: path
+  name: transformer_id
+  required: true
+  description: id of the combinator
+- in: path
+  name: metric_id
+  required: true
+  description: id of the metric
+responses:
+  '200':
+    description: source specific name for config items and list of configuration items
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            configItemName:
+              type: string
+            configItems:
+              type: array
+              items:
+                $ref: "#/components/schemas/ConfigItem"
+  '404':
+    description: metric not found for given combinator
+produces:
+- application/json

--- a/api_doc/transformer/patch_combinator_metric_expression.yaml
+++ b/api_doc/transformer/patch_combinator_metric_expression.yaml
@@ -20,10 +20,13 @@ requestBody:
           expression:
             description: the expression of the combined metric
             type: object
+          configHash:
+            descirption: the config hash provided by the api on get
+            type: string
 responses:
   '204':
     description: the expression of the combined metric was updated
   '400':
-    description: the combined metric doesn't exist
+    description: the combined metric doesn't exist or the config hash mismatches
 produces:
 - application/json

--- a/api_doc/transformer/patch_combinator_metric_expression.yaml
+++ b/api_doc/transformer/patch_combinator_metric_expression.yaml
@@ -1,0 +1,29 @@
+description: Update a combined metric expression
+tags:
+- Transformer
+parameters:
+- in: path
+  name: transformer_id
+  required: true
+  description: id of the combinator
+- in: path
+  name: metric_id
+  required: true
+  description: id of the metric
+requestBody:
+  description: new expression of the combined metric
+  content:
+    'application/json':
+      schema:
+        type: object
+        properties:
+          expression:
+            description: the expression of the combined metric
+            type: object
+responses:
+  '204':
+    description: the expression of the combined metric was updated
+  '400':
+    description: the combined metric doesn't exist
+produces:
+- application/json

--- a/api_doc/transformer/put_combinator_metric_expression.yaml
+++ b/api_doc/transformer/put_combinator_metric_expression.yaml
@@ -1,0 +1,29 @@
+description: Create a new combined metric, provided by given combinator
+tags:
+- Transformer
+parameters:
+- in: path
+  name: transformer_id
+  required: true
+  description: id of the combinator
+- in: path
+  name: metric_id
+  required: true
+  description: id of the metric
+requestBody:
+  description: expression of the new combined metric
+  content:
+    'application/json':
+      schema:
+        type: object
+        properties:
+          expression:
+            description: the expression of the new combined metric
+            type: object
+responses:
+  '204':
+    description: the new combined metric was created
+  '400':
+    description: the combined metric already exists
+produces:
+- application/json

--- a/app/api/views/transformer.py
+++ b/app/api/views/transformer.py
@@ -40,7 +40,12 @@ async def get_transformer_list(request: Request):
     for config_id, config in config_dict.items():
         if config_id.startswith("transformer-"):
             try:
-                transformer_list.append({"id": config_id})
+                transformer_list.append(
+                    {
+                        "id": config_id,
+                        "isCombinator": "combinator" in config_id.lower(),
+                    }
+                )
             except KeyError:
                 logger.error(
                     f"Config of transformer {config_id} is incorrect! Missing key"

--- a/app/api/views/transformer.py
+++ b/app/api/views/transformer.py
@@ -74,7 +74,8 @@ async def get_combinator_metric_expression(request: Request):
             {
                 "transformerId": transformer_id,
                 "metric": metric_id,
-                "expression": expression,
+                "expression": expression["expression"],
+                "configHash": expression["config_hash"],
             }
         ),
         content_type="application/json",
@@ -114,10 +115,11 @@ async def patch_combinator_metric_expression(request: Request):
     request_data = await request.json()
 
     new_expression = request_data.get("expression")
+    config_hash = request_data.get("configHash")
 
-    if new_expression:
+    if new_expression and config_hash:
         if await configurator.update_combined_metric_expression(
-            transformer_id, metric_id, new_expression
+            transformer_id, metric_id, new_expression, config_hash
         ):
             return Response(
                 status=204,


### PR DESCRIPTION
This adds support for creating and editing combined metrics via API. Required by metricq/metricq-wizard-frontend#11