### PR TITLE
fix: rename config option of pydantic model

### DIFF
--- a/metricq_wizard_backend/metricq/source_plugin.py
+++ b/metricq_wizard_backend/metricq/source_plugin.py
@@ -31,7 +31,7 @@ class AddMetricItem(pydantic.BaseModel):
     custom_columns_values: Dict
 
     class Config:
-        allow_population_by_alias = True
+        allow_population_by_field_name = True
 
         @classmethod
         def alias_generator(cls, string: str) -> str:
@@ -44,7 +44,7 @@ class AvailableMetricItem(pydantic.BaseModel):
     custom_columns: Dict
 
     class Config:
-        allow_population_by_alias = True
+        allow_population_by_field_name = True
 
         @classmethod
         def alias_generator(cls, string: str) -> str:


### PR DESCRIPTION
allow_population_by_alias was already deprecated in v1.0  and is removed in newer versions