### PR TITLE
feat: add DELETE /api/client/{token} route

### DIFF
--- a/metricq_wizard_backend/api/views/client.py
+++ b/metricq_wizard_backend/api/views/client.py
@@ -72,6 +72,16 @@ async def create_client(request: Request):
     return json_response(data={"status": "success"})
 
 
+@routes.delete("/api/client/{token}")
+async def delete_client(request: Request):
+    token: str = request.match_info["token"]
+    configurator: Configurator = request.app["metricq_client"]
+    if not request.app["settings"].dry_run:
+        await configurator.delete_client(token=token)
+
+    return json_response(data={"status": "success"})
+
+
 @swagger_path("api_doc/reconfigure_client.yaml")
 @routes.post("/api/client/{token}/reconfigure")
 async def reconfigure_client(request: Request):

--- a/metricq_wizard_backend/api/views/client.py
+++ b/metricq_wizard_backend/api/views/client.py
@@ -77,7 +77,14 @@ async def delete_client(request: Request):
     token: str = request.match_info["token"]
     configurator: Configurator = request.app["metricq_client"]
     if not request.app["settings"].dry_run:
-        await configurator.delete_client(token=token)
+        if not await configurator.delete_client(token=token):
+            return json_response(
+                data={
+                    "status": "error",
+                    "message": f"client with token '{token}' does not exist.",
+                },
+                status=404,
+            )
 
     return json_response(data={"status": "success"})
 


### PR DESCRIPTION
Adds a new route that removes clients, both the config and the stored discover entry.

Will response with a 404 if the given token neither has a config nor a discovery entry in the client database.