### PR TITLE
Adds Cluster Health enpoint with several checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/metricq/metricq-python:v4.2 AS builder
+FROM ghcr.io/metricq/metricq-python:v5.3 AS builder
 LABEL maintainer="franz.hoepfner@tu-dresden.de"
 
 USER root
@@ -23,7 +23,7 @@ RUN pip install --user . gunicorn \
 WORKDIR /home/metricq
 RUN wget -O wait-for-it.sh https://github.com/vishnubob/wait-for-it/raw/master/wait-for-it.sh && chmod +x wait-for-it.sh
 
-FROM ghcr.io/metricq/metricq-python:v4.2
+FROM ghcr.io/metricq/metricq-python:v5.3
 LABEL maintainer="franz.hoepfner@tu-dresden.de"
 
 RUN mkdir -p /home/metricq/wizard/config-backup

--- a/metricq_wizard_backend/api/views/__init__.py
+++ b/metricq_wizard_backend/api/views/__init__.py
@@ -4,6 +4,7 @@ from .metric import routes as metric_routes
 from .source import routes as source_routes
 from .topology import routes as topology_routes
 from .transformer import routes as transformer_routes
+from .cluster import routes as cluster_routes
 
 
 def add_routes_to_app(app):
@@ -13,3 +14,4 @@ def add_routes_to_app(app):
     app.router.add_routes(source_routes)
     app.router.add_routes(transformer_routes)
     app.router.add_routes(topology_routes)
+    app.router.add_routes(cluster_routes)

--- a/metricq_wizard_backend/api/views/cluster.py
+++ b/metricq_wizard_backend/api/views/cluster.py
@@ -41,10 +41,10 @@ async def get_client_list_filtered(request: Request):
 
 @routes.delete("/api/cluster/issues/{issue}")
 async def delete_issue(request: Request):
-    configurator: Configurator = request.app["metricq_client"]
+    scanner: ClusterScanner = request.app["cluster_scanner"]
     issue = request.match_info["issue"]
 
-    await configurator.delete_issue_report(*issue.split("-"))
+    await scanner.delete_issue_report(*issue.split("-"))
 
     return json_response(data={"status": "ok"})
 

--- a/metricq_wizard_backend/api/views/cluster.py
+++ b/metricq_wizard_backend/api/views/cluster.py
@@ -1,0 +1,50 @@
+# metricq-wizard
+# Copyright (C) 2023 ZIH, Technische Universitaet Dresden, Federal Republic of Germany
+#
+# All rights reserved.
+#
+# This file is part of metricq-wizard.
+#
+# metricq-wizard is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# metricq-wizard is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with metricq-wizard.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+
+import metricq
+from aiohttp.web_request import Request
+from aiohttp.web_response import json_response
+from aiohttp.web_routedef import RouteTableDef
+from aiohttp_swagger import swagger_path
+
+from metricq_wizard_backend.metricq import Configurator
+
+logger = metricq.get_logger()
+logger.setLevel("DEBUG")
+
+routes = RouteTableDef()
+
+
+@routes.get("/api/cluster/issues")
+async def get_client_list(request: Request):
+    configurator: Configurator = request.app["metricq_client"]
+
+    return json_response(data=await configurator.get_cluster_issues())
+
+
+@routes.post("/api/cluster/health_scan")
+async def get_client_list(request: Request):
+    configurator: Configurator = request.app["metricq_client"]
+
+    asyncio.create_task(configurator.scan_cluster())
+
+    return json_response(data={"status": "created"}, status=202)

--- a/metricq_wizard_backend/api/views/cluster.py
+++ b/metricq_wizard_backend/api/views/cluster.py
@@ -24,7 +24,6 @@ import metricq
 from aiohttp.web_request import Request
 from aiohttp.web_response import json_response
 from aiohttp.web_routedef import RouteTableDef
-from aiohttp_swagger import swagger_path
 
 from metricq_wizard_backend.metricq import Configurator
 
@@ -39,6 +38,15 @@ async def get_client_list(request: Request):
     configurator: Configurator = request.app["metricq_client"]
 
     return json_response(data=await configurator.get_cluster_issues())
+
+
+@routes.post("/api/cluster/issues")
+async def get_client_list_filtered(request: Request):
+    configurator: Configurator = request.app["metricq_client"]
+
+    ctx = await request.json()
+
+    return json_response(data=await configurator.find_cluster_issues(**ctx))
 
 
 @routes.post("/api/cluster/health_scan")

--- a/metricq_wizard_backend/api/views/cluster.py
+++ b/metricq_wizard_backend/api/views/cluster.py
@@ -42,9 +42,19 @@ async def get_client_list(request: Request):
 
 
 @routes.post("/api/cluster/health_scan")
-async def get_client_list(request: Request):
+async def post_health_scan(request: Request):
     configurator: Configurator = request.app["metricq_client"]
 
     asyncio.create_task(configurator.scan_cluster())
 
     return json_response(data={"status": "created"}, status=202)
+
+
+@routes.delete("/api/cluster/issues/{issue}")
+async def delete_issue(request: Request):
+    configurator: Configurator = request.app["metricq_client"]
+    issue = request.match_info["issue"]
+
+    await configurator.delete_issue_report(*issue.split("-"))
+
+    return json_response(data={"status": "ok"})

--- a/metricq_wizard_backend/api/views/metric.py
+++ b/metricq_wizard_backend/api/views/metric.py
@@ -373,7 +373,7 @@ async def get_metric_consumers(request: Request):
 
     consumers = await configurator.fetch_consumers(metric=metric_id)
 
-    return Response(text=json.dumps(consumers), content_type="application/json")
+    return json_response(consumers)
 
 
 @routes.get("/api/metric/{id}/issues")
@@ -381,6 +381,4 @@ async def get_metric_issues(request: Request):
     metric = request.match_info["id"]
     scanner: ClusterScanner = request.app["cluster_scanner"]
 
-    issues = await scanner.get_metric_issues(metric)
-
-    return json_response(issues)
+    return json_response({"issues": await scanner.get_metric_issues(metric)})

--- a/metricq_wizard_backend/api/views/metric.py
+++ b/metricq_wizard_backend/api/views/metric.py
@@ -205,7 +205,7 @@ async def post_metrics_historic(request: Request):
 
     metrics: dict[metricq.Metric, bool] = data["metrics"]
 
-    if any([not isinstance(id, str) or not isinstance(value, bool) for id, value in metrics]) or len(metrics) == 0:
+    if any([not isinstance(id, str) or not isinstance(value, bool) for id, value in metrics.items()]) or len(metrics) == 0:
         return json_response(
             {"status": "error", "message": "Invalid metric dict in request"},
             status=400

--- a/metricq_wizard_backend/api/views/metric.py
+++ b/metricq_wizard_backend/api/views/metric.py
@@ -195,7 +195,7 @@ async def post_metrics_archive(request: Request):
                 "archived": archived_metrics,
                 "failed": list(set(metrics) - set(archived_metrics)),
             },
-            status=400,
+            status=500,
         )
 
 

--- a/metricq_wizard_backend/metricq/__init__.py
+++ b/metricq_wizard_backend/metricq/__init__.py
@@ -1,3 +1,4 @@
 from .configurator import Configurator
+from .cluster_scanner import ClusterScanner
 
-__all__ = ["Configurator"]
+__all__ = ["Configurator", "ClusterScanner"]

--- a/metricq_wizard_backend/metricq/cluster_scanner.py
+++ b/metricq_wizard_backend/metricq/cluster_scanner.py
@@ -171,11 +171,12 @@ class ClusterScanner:
             # only set first_detection_date when creating the report, not
             # on updates
             report["first_detection_date"] = (
-                str(Timestamp.now().datetime.astimezone()) if date is None else date
+                str(Timestamp.now().datetime.isoformat()
+                    ) if date is None else date
             )
 
         report["date"] = (
-            str(Timestamp.now().datetime.astimezone()) if date is None else date
+            str(Timestamp.now().datetime.isoformat()) if date is None else date
         )
 
         report["type"] = type
@@ -335,7 +336,7 @@ class ClusterScanner:
                     scope=metric,
                     type="dead",
                     severity="error",
-                    last_timestamp=str(result.timestamp.datetime.astimezone()),
+                    last_timestamp=str(result.timestamp.datetime.isoformat()),
                     source=metadata.get("source"),
                 )
                 # if the metric is dead, it can't be undead as well
@@ -352,7 +353,7 @@ class ClusterScanner:
                     scope=metric,
                     type="undead",
                     severity="warning",
-                    last_timestamp=str(result.timestamp.datetime.astimezone()),
+                    last_timestamp=str(result.timestamp.datetime.isoformat()),
                     source=metadata.get("source"),
                     archived=metadata.get("archived"),
                 )
@@ -407,7 +408,7 @@ class ClusterScanner:
         metric: str,
         metadata: JsonDict,
     ) -> None:
-        start_time = Timestamp.from_iso8601("1970-01-01T00:00:00.0Z")
+        start_time = Timestamp(0)
         end_time = Timestamp.from_now(Timedelta.from_string("7d"))
 
         try:
@@ -415,14 +416,15 @@ class ClusterScanner:
                 metric, start_time=start_time, end_time=end_time, timeout=60
             )
             if result.count and (
-                not math.isfinite(result.minimum) or not math.isfinite(result.maximum)
+                not math.isfinite(result.minimum) or not math.isfinite(
+                    result.maximum)
             ):
                 await self.create_issue_report(
                     scope_type="metric",
                     scope=metric,
                     type="infinite",
                     severity="info",
-                    last_timestamp=str(result.timestamp.datetime.astimezone()),
+                    last_timestamp=str(result.timestamp.datetime.isoformat()),
                     source=metadata.get("source"),
                 )
             else:

--- a/metricq_wizard_backend/metricq/cluster_scanner.py
+++ b/metricq_wizard_backend/metricq/cluster_scanner.py
@@ -301,6 +301,7 @@ class ClusterScanner:
                     )
 
         try:
+            request_time = Timestamp.now()
             result = await client.history_last_value(metric, timeout=60)
 
             if result is None:
@@ -321,7 +322,7 @@ class ClusterScanner:
                 type="no_value",
             )
 
-            age = Timestamp.now() - result.timestamp
+            age = request_time - result.timestamp
 
             # Archived metrics are supposed to not receive new data points.
             # For such metrics, the archived metadata is the ISO8601 string, when

--- a/metricq_wizard_backend/metricq/cluster_scanner.py
+++ b/metricq_wizard_backend/metricq/cluster_scanner.py
@@ -1,0 +1,413 @@
+import asyncio
+import math
+import re
+from typing import Any
+
+from aiocouch import CouchDB, Database
+from metricq import HistoryClient, Timedelta, Timestamp
+from metricq.exceptions import HistoryError
+from metricq.logging import get_logger
+
+JsonDict = dict[str, Any]
+
+logger = get_logger()
+logger.setLevel("INFO")
+
+
+class ClusterScanner:
+    def __init__(self, token: str, url: str, couch: CouchDB):
+        self.token = token
+        self.url = url
+        self.couch = couch
+
+        self.db_issues: Database | None = None
+        self.db_metadata: Database | None = None
+
+        self.lock: asyncio.Lock | None = None
+
+    async def connect(self):
+        self.lock = asyncio.Lock()
+
+        self.db_metadata = await self.couch.create("metadata", exists_ok=True)
+
+        self.db_issues = await self.couch.create("issues", exists_ok=True)
+
+        index = await self.db_issues.design_doc("sortedBy", exists_ok=True)
+        await index.create_view(
+            view="scope",
+            map_function="function (doc) {\n  emit(doc.scope_type + doc.scope, null);\n}",
+            exists_ok=True,
+        )
+        await index.create_view(
+            view="scope",
+            map_function="function (doc) {\n  emit(doc.scope_type + doc.scope, null);\n}",
+            exists_ok=True,
+        )
+        await index.create_view(
+            view="severity",
+            map_function='function (doc) {\n  if (doc.severity == "error") {\n    emit(1, null);\n } else if (doc.severity == "warning") {\n emit(2, null);\n } else {\n emit(3, null);\n }\n }',
+            exists_ok=True,
+        )
+        await index.create_view(
+            view="type",
+            map_function="function (doc) {\n emit(doc.type, null);\n }",
+            exists_ok=True,
+        )
+
+    async def scan_cluster(self) -> None:
+        if self.lock.locked():
+            raise RuntimeError("Scan already running")
+
+        async with self.lock():
+            logger.warn("Starting Cluster Health Scan")
+
+            # TODO add check for queue bindings
+
+            async with HistoryClient(self.token, self.url, add_uuid=True) as client:
+
+                async with asyncio.TaskGroup() as tasks:
+                    async for metric, metadata in self.db_metadata.docs():
+                        tasks.create_task(self.check_metric_metadata(metric, metadata),)
+                        tasks.create_task(
+                            self.check_metric_is_dead(client, metric, metadata)
+                        )
+                        tasks.create_task(
+                            self.check_metric_for_infinites(client, metric, metadata)
+                        )
+                        # there is no tooling for renaming metrics, so bad
+                        # names is nothing we should warn about yet.
+                        # tasks.create_task( self.check_metric_name(metric))
+
+                await asyncio.gather(*tasks)
+
+            logger.warn("Cluster Health Scan Finished")
+
+    async def create_issue_report(
+        self,
+        type: str,
+        scope_type: str,
+        scope: str,
+        date: str = None,
+        severity: str = None,
+        **kwargs: Any,
+    ):
+        report = await self.db_issues.create(
+            id=f"{type}-{scope_type}-{scope}", exists_ok=True
+        )
+
+        report["severity"] = "warning" if severity is None else severity
+
+        if "first_detection_date" not in report:
+            # only set first_detection_date when creating the report, not
+            # on updates
+            report["first_detection_date"] = (
+                str(Timestamp.now().datetime.astimezone()) if date is None else date
+            )
+
+        report["date"] = (
+            str(Timestamp.now().datetime.astimezone()) if date is None else date
+        )
+
+        report["type"] = type
+        report["scope_type"] = scope_type
+        report["scope"] = scope
+
+        # entries in the new kwargs should overwrite existing entries
+        for key, val in kwargs.items():
+            report[key] = val
+
+        await report.save()
+
+    async def delete_issue_report(
+        self,
+        type: str,
+        scope_type: str,
+        scope: str,
+    ):
+        report = await self.db_issues.create(
+            id=f"{type}-{scope_type}-{scope}", exists_ok=True
+        )
+        if report.exists:
+            await report.delete()
+
+    async def check_metric_metadata(self, metric, metadata):
+        try:
+            source = metadata["source"]
+        except KeyError:
+            source = None
+
+        # This check is extra from missing_metadata, because it is a bit
+        # more important, but new. We want to enforce that every metric has
+        # to be either historic or not historic, i.e. only live. Or in other
+        # words, not setting it is not an option.
+        if "historic" not in metadata or not isinstance(metadata["historic"], bool):
+            await self.create_issue_report(
+                scope_type="metric",
+                scope=metric,
+                type="missing_historic",
+                severity="warn",
+                source=source,
+            )
+        else:
+            await self.delete_issue_report(
+                scope_type="metric",
+                scope=metric,
+                type="missing_historic",
+            )
+
+        missing_metadata = []
+
+        if "rate" not in metadata or not isinstance(metadata["rate"], float):
+            missing_metadata.append("rate")
+
+        if (
+            "description" not in metadata
+            or not isinstance(metadata["description"], str)
+            or not metadata["description"]
+        ):
+            missing_metadata.append("description")
+
+        if (
+            "unit" not in metadata
+            or not isinstance(metadata["unit"], str)
+            or not metadata["unit"]
+        ):
+            missing_metadata.append("unit")
+
+        if (
+            "source" not in metadata
+            or not isinstance(metadata["source"], str)
+            or not metadata["source"]
+        ):
+            missing_metadata.append("source")
+
+        if missing_metadata:
+            await self.create_issue_report(
+                scope_type="metric",
+                scope=metric,
+                type="missing_metadata",
+                severity="error" if "source" in missing_metadata else "info",
+                source=source,
+                missing_metadata=missing_metadata,
+            )
+        else:
+            await self.delete_issue_report(
+                scope_type="metric",
+                scope=metric,
+                type="missing_metadata",
+            )
+
+    async def check_metrics_for_dead(
+        self, client: HistoryClient, metrics: dict[str, JsonDict]
+    ) -> None:
+        async def check_metric(metric: str, allowed_age: Timedelta) -> None:
+            try:
+                result = await client.history_last_value(metric, timeout=60)
+
+                if result is None:
+                    # No data points stored yet. This is bad.
+                    await self.create_issue_report(
+                        scope_type="metric",
+                        scope=metric,
+                        type="no_value",
+                        severity="warning",
+                        source=metrics[metric].get("source"),
+                    )
+                    return
+
+                # we have a valid result, hence, there are stored data points.
+                await self.delete_issue_report(
+                    scope_type="metric",
+                    scope=metric,
+                    type="no_value",
+                )
+
+                age = Timestamp.now() - result.timestamp
+
+                # Archived metrics are supposed to not receive new data points.
+                # For such metrics, the archived metadata is the ISO8601 string, when
+                # the metric was archived.
+                if age > allowed_age and not metrics[metric].get("archived"):
+                    # We haven't received a new data point in a while and the metric
+                    # wasn't archived => It's dead, Jimmy.
+                    await self.create_issue_report(
+                        scope_type="metric",
+                        scope=metric,
+                        type="dead",
+                        severity="error",
+                        last_timestamp=str(result.timestamp.datetime.astimezone()),
+                        source=metrics[metric].get("source"),
+                    )
+                    # if the metric is dead, it can't be undead as well
+                    await self.delete_issue_report(
+                        scope_type="metric",
+                        scope=metric,
+                        type="undead",
+                    )
+                elif age <= allowed_age and metrics[metric].get("archived") is not None:
+                    # the metric is archived, but we recently received a new data point
+                    # => Zombies are here, back in my dayz, you'd reload your hatchet now.
+                    await self.create_issue_report(
+                        scope_type="metric",
+                        scope=metric,
+                        type="undead",
+                        severity="warning",
+                        last_timestamp=str(result.timestamp.datetime.astimezone()),
+                        source=metrics[metric].get("source"),
+                        archived=metrics[metric].get("archived"),
+                    )
+                    # if the metric is undead, it can't be dead as well
+                    await self.delete_issue_report(
+                        scope_type="metric",
+                        scope=metric,
+                        type="dead",
+                    )
+                else:
+                    # this is the happy case, everything's fine.
+                    await self.delete_issue_report(
+                        scope_type="metric",
+                        scope=metric,
+                        type="dead",
+                    )
+                    await self.delete_issue_report(
+                        scope_type="metric",
+                        scope=metric,
+                        type="undead",
+                    )
+
+                # if we got here, the metric didn't time out. so remove those reports
+                await self.delete_issue_report(
+                    scope_type="metric",
+                    scope=metric,
+                    type="timeout",
+                )
+
+            except asyncio.TimeoutError:
+                # this likely means that the bindings for this metric is borked
+                await self.create_issue_report(
+                    scope_type="metric",
+                    scope=metric,
+                    severity="warning",
+                    type="timeout",
+                    source=metrics[metric].get("source"),
+                )
+            except HistoryError as e:
+                await self.create_issue_report(
+                    scope_type="metric",
+                    scope=metric,
+                    type="errored",
+                    severity="info",
+                    error=str(e),
+                    source=metrics[metric].get("source"),
+                )
+
+        def compute_allowed_age(metadata: JsonDict) -> Timedelta:
+            # TODO tolerance is rather high, because in prod, checks seem to
+            # take a while, which messes up the timings :(
+            tolerance = Timedelta.from_string("1min")
+            try:
+                rate = metadata["rate"]
+                if not isinstance(rate, (int, float)):
+                    logger.error(
+                        "Invalid rate: {} ({}) [{}]",
+                        rate,
+                        type(rate),
+                        metadata,
+                    )
+                else:
+                    tolerance += Timedelta.from_s(1 / rate)
+            except KeyError:
+                # Fall back to compute tolerance from interval
+                try:
+                    interval = metadata["interval"]
+                    if isinstance(interval, str):
+                        tolerance += Timedelta.from_string(interval)
+                    elif isinstance(interval, (int, float)):
+                        tolerance += Timedelta.from_s(interval)
+                    else:
+                        logger.error(
+                            "Invalid interval: {} ({}) [{}]",
+                            interval,
+                            type(interval),
+                            metadata,
+                        )
+                except KeyError:
+                    pass
+            return tolerance
+
+        requests = [
+            check_metric(metric, compute_allowed_age(metadata))
+            for metric, metadata in metrics.items()
+        ]
+
+        for request in asyncio.as_completed(requests):
+            await request
+
+    async def check_metric_for_infinites(
+        self,
+        client: HistoryClient,
+        metric: str,
+        metadata: JsonDict,
+    ) -> None:
+        start_time = Timestamp.from_iso8601("1970-01-01T00:00:00.0Z")
+        end_time = Timestamp.from_now(Timedelta.from_string("7d"))
+
+        try:
+            result = await client.history_aggregate(
+                metric, start_time=start_time, end_time=end_time, timeout=60
+            )
+            if result.count and (
+                not math.isfinite(result.minimum) or not math.isfinite(result.maximum)
+            ):
+                await self.create_issue_report(
+                    scope_type="metric",
+                    scope=metric,
+                    type="infinite",
+                    severity="info",
+                    last_timestamp=str(result.timestamp.datetime.astimezone()),
+                    source=metadata.get("source"),
+                )
+            else:
+                await self.delete_issue_report(
+                    scope_type="metric",
+                    scope=metric,
+                    type="infinite",
+                )
+
+        except asyncio.TimeoutError:
+            # we should see this in the dead metrics check as well, so don't bother here.
+            pass
+        except HistoryError as e:
+            await self.create_issue_report(
+                scope_type="metric",
+                scope=metric,
+                type="errored",
+                severity="info",
+                error=str(e),
+                source=metadata.get("source"),
+            )
+
+    async def check_metric_names(self):
+        """
+        Checks all metric names in the database against the regex.
+        """
+        async for metric in self.db_metadata.all_docs.ids():
+            if metric.startswith("_design/"):
+                # these are special, don't touch them
+                continue
+
+            if not re.match(r"([a-zA-Z][a-zA-Z0-9_]+\.)+[a-zA-Z][a-zA-Z0-9_]+", metric):
+                doc = await self.db_metadata.get(metric)
+                await self.create_issue_report(
+                    scope_type="metric",
+                    scope=metric,
+                    type="invalid_name",
+                    severity="info",
+                    source=doc.get("source"),
+                )
+            else:
+                await self.delete_issue_report(
+                    scope_type="metric",
+                    scope=metric,
+                    type="invalid_name",
+                )

--- a/metricq_wizard_backend/metricq/configurator.py
+++ b/metricq_wizard_backend/metricq/configurator.py
@@ -241,7 +241,8 @@ class Configurator(Client):
                     selector_dict["_id"] = {"$in": selector}
             else:
                 raise TypeError(
-                    "Invalid selector type: {}, supported: str, list", type(selector)
+                    "Invalid selector type: {}, supported: str, list", type(
+                        selector)
                 )
 
         if selector_dict:
@@ -300,7 +301,8 @@ class Configurator(Client):
     ):
         configurations_by_database = {}
         for config in metric_database_configurations:
-            config_list = configurations_by_database.get(config.database_id, [])
+            config_list = configurations_by_database.get(
+                config.database_id, [])
             config_list.append(config)
             configurations_by_database[config.database_id] = config_list
 
@@ -321,7 +323,8 @@ class Configurator(Client):
 
                         if metadata:
                             if metadata.get("historic", False):
-                                logger.warn("Metric already in a database. Ignoring!")
+                                logger.warn(
+                                    "Metric already in a database. Ignoring!")
                             else:
                                 if (
                                     metric_database_configuration.id
@@ -485,10 +488,12 @@ class Configurator(Client):
             raise AttributeError("unknown format requested: {}".format(format))
 
         if infix is not None and prefix is not None:
-            raise AttributeError('cannot get_metrics with both "prefix" and "infix"')
+            raise AttributeError(
+                'cannot get_metrics with both "prefix" and "infix"')
 
         if source is not None and historic is not None:
-            raise AttributeError('cannot get_metrics with both "historic" and "source"')
+            raise AttributeError(
+                'cannot get_metrics with both "historic" and "source"')
 
         selector_dict = dict()
         if selector is not None:
@@ -504,7 +509,8 @@ class Configurator(Client):
                     selector_dict["_id"] = {"$in": selector}
             else:
                 raise TypeError(
-                    "Invalid selector type: {}, supported: str, list", type(selector)
+                    "Invalid selector type: {}, supported: str, list", type(
+                        selector)
                 )
         if historic is not None:
             if not isinstance(historic, bool):
@@ -536,7 +542,8 @@ class Configurator(Client):
             if infix is None:
                 request_prefix = prefix
                 if historic:
-                    endpoint = self.couchdb_db_metadata.view("index", "historic")
+                    endpoint = self.couchdb_db_metadata.view(
+                        "index", "historic")
                 elif source is not None:
                     endpoint = self.couchdb_db_metadata.view("index", "source")
                     request_prefix = None
@@ -550,9 +557,11 @@ class Configurator(Client):
                 if limit is not None:
                     request_limit = 6 * limit
                 if historic:
-                    endpoint = self.couchdb_db_metadata.view("components", "historic")
+                    endpoint = self.couchdb_db_metadata.view(
+                        "components", "historic")
                 else:
-                    endpoint = self.couchdb_db_metadata.view("components", "all")
+                    endpoint = self.couchdb_db_metadata.view(
+                        "components", "all")
 
             if format == "array":
                 metrics = [
@@ -583,7 +592,8 @@ class Configurator(Client):
         for transformer_metric in config.get("metrics", {}):
             if transformer_metric == metric:
                 config_hash = hashlib.sha256(
-                    json.dumps(config["metrics"][transformer_metric]).encode("utf-8")
+                    json.dumps(config["metrics"]
+                               [transformer_metric]).encode("utf-8")
                 ).hexdigest()
                 logger.info("JSON hash is {}", config_hash)
                 return {
@@ -763,7 +773,8 @@ class Configurator(Client):
 
             try:
                 if "archived" not in doc:
-                    doc["archived"] = str(metricq.Timestamp.now().datetime.astimezone())
+                    doc["archived"] = str(
+                        metricq.Timestamp.now().datetime.astimezone())
 
                     await doc.save()
 
@@ -825,7 +836,8 @@ class Configurator(Client):
             )
 
         report["date"] = (
-            str(metricq.Timestamp.now().datetime.astimezone()) if date is None else date
+            str(metricq.Timestamp.now().datetime.astimezone()
+                ) if date is None else date
         )
 
         report["type"] = type
@@ -894,12 +906,19 @@ class Configurator(Client):
             ):
                 missing_metadata.append("unit")
 
+            if (
+                "source" not in metadata
+                or not isinstance(metadata["source"], str)
+                or not metadata["source"]
+            ):
+                missing_metadata.append("source")
+
             if missing_metadata:
                 await self.create_issue_report(
                     scope_type="metric",
                     scope=metric,
                     type="missing_metadata",
-                    severity="info",
+                    severity="error" if "source" in missing_metadata else "info",
                     source=source,
                     missing_metadata=missing_metadata,
                 )
@@ -956,7 +975,8 @@ class Configurator(Client):
                         scope=metric,
                         type="dead",
                         severity="error",
-                        last_timestamp=str(result.timestamp.datetime.astimezone()),
+                        last_timestamp=str(
+                            result.timestamp.datetime.astimezone()),
                         source=metrics[metric].get("source"),
                     )
                     # if the metric is dead, it can't be undead as well
@@ -973,7 +993,8 @@ class Configurator(Client):
                         scope=metric,
                         type="undead",
                         severity="warning",
-                        last_timestamp=str(result.timestamp.datetime.astimezone()),
+                        last_timestamp=str(
+                            result.timestamp.datetime.astimezone()),
                         source=metrics[metric].get("source"),
                         archived=metrics[metric].get("archived"),
                     )
@@ -1028,7 +1049,8 @@ class Configurator(Client):
                 rate = metadata["rate"]
                 if not isinstance(rate, (int, float)):
                     logger.error(
-                        "Invalid rate: {} ({}) [{}]", rate, type(rate), metadata
+                        "Invalid rate: {} ({}) [{}]", rate, type(
+                            rate), metadata
                     )
                 else:
                     tolerance += metricq.Timedelta.from_s(1 / rate)
@@ -1063,7 +1085,8 @@ class Configurator(Client):
         self, client: metricq.HistoryClient, metrics: dict[str, JsonDict]
     ) -> None:
         start_time = metricq.Timestamp.from_iso8601("1970-01-01T00:00:00.0Z")
-        end_time = metricq.Timestamp.from_now(metricq.Timedelta.from_string("7d"))
+        end_time = metricq.Timestamp.from_now(
+            metricq.Timedelta.from_string("7d"))
 
         async def check_metric(metric: str) -> None:
             try:
@@ -1079,7 +1102,8 @@ class Configurator(Client):
                         scope=metric,
                         type="infinite",
                         severity="info",
-                        last_timestamp=str(result.timestamp.datetime.astimezone()),
+                        last_timestamp=str(
+                            result.timestamp.datetime.astimezone()),
                         source=metrics[metric].get("source"),
                     )
                 else:
@@ -1134,3 +1158,22 @@ class Configurator(Client):
 
     async def get_cluster_issues(self):
         return [doc.data async for doc in self.couchdb_db_issues.all_docs.docs()]
+
+    async def find_cluster_issues(self, currentPage, perPage, sortBy, sortDesc, **kwargs):
+        skip = (currentPage - 1) * perPage
+        limit = perPage
+
+        if sortBy == "id":
+            view = self.couchdb_db_issues.all_docs
+        elif sortBy == "severity":
+            view = self.couchdb_db_issues.view("sortedBy", "severity")
+        elif sortBy == "scope":
+            view = self.couchdb_db_issues.view("sortedBy", "scope")
+        elif sortBy == "issue":
+            view = self.couchdb_db_issues.view("sortedBy", "type")
+
+        response = await view.get(include_docs=True, limit=limit, skip=skip, descending=sortDesc)
+        return {
+            "totalRows": response.total_rows,
+            "rows": [doc.data for doc in response.docs()],
+        }

--- a/metricq_wizard_backend/metricq/configurator.py
+++ b/metricq_wizard_backend/metricq/configurator.py
@@ -1044,7 +1044,9 @@ class Configurator(Client):
                 )
 
         def compute_allowed_age(metadata: JsonDict) -> metricq.Timedelta:
-            tolerance = metricq.Timedelta.from_string("1s")
+            # TODO tolerance is rather high, because in prod, checks seem to
+            # take a while, which messes up the timings :(
+            tolerance = metricq.Timedelta.from_string("1min")
             try:
                 rate = metadata["rate"]
                 if not isinstance(rate, (int, float)):

--- a/metricq_wizard_backend/settings.py
+++ b/metricq_wizard_backend/settings.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     rabbitmq_url: stricturl(
         tld_required=False, allowed_schemes={"amqp", "amqps"}  # noqa: F821
     ) = "amqp://admin:admin@localhost/"
-    couchdb_url: AnyHttpUrl = "http://localhost:5984"
+    couchdb_url: AnyHttpUrl = "http://admin:admin@localhost:5984"
     rabbitmq_api_url: AnyHttpUrl = "http://admin:admin@localhost:15672"
     rabbitmq_data_host: str = "/"
     dry_run = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     aiohttp-session[secure]~=2.9
     aiohttp-swagger~=1.0
     pydantic~=1.0
-    aiocouch
+    aiocouch~=3.0
     aiocache
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ python_requires = >=3.10
 setup_requires =
     setuptools_scm
 install_requires =
-    metricq ~= 4.0
+    metricq ~= 5.2
     aiohttp~=3.7
     aiohttp-cors~=0.7
     aiohttp-jinja2~=1.2


### PR DESCRIPTION
Checks:
 - Check for invalid Metadata (`source`, `rate`, `unit`, `description`)
 - Check that Metrics are either live-only (`historic: false`) or saved in a DB (`historic: true`)
 - Check for infinite values stored in a historic metric
 - Check for dead metrics, aka. metrics which are supposed to contain recent data points but don't
 - Check for undead metrics, aka. metrics which are supposed to not contain recent data points but do
 - [Diabled] Check metric names against the valid metric name regex

Also adds some resemblance of Metric Life Cycle Management:
 - Freshly created metrics have neither `historic` nor `archived` set
 - Fresh metrics can be deleted using the wizard
 - Normal Operation: either set `historic` to `true` or `false`
 - Decommission:  set `archived` to iso date string
